### PR TITLE
Add Claude crossword generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This tool generates crossword puzzle books for Amazon KDP. Provide a theme and n
 - Python 3.10+
 - `requests`
 - `reportlab`
+- `anthropic` (optional, for Claude integration)
 
 Install dependencies:
 ```bash
@@ -15,6 +16,14 @@ pip install -r requirements.txt
 ## Usage
 ```
 python main.py "animals" 20 --size 6x9 --output animals_book.pdf
+```
+
+To generate puzzles using Claude instead of the local generator, add the
+`--use-claude` flag. This requires setting the `ANTHROPIC_API_KEY`
+environment variable with your API key:
+
+```
+ANTHROPIC_API_KEY=<your_key> python main.py "animals" 20 --use-claude
 ```
 
 This will create `animals_book.pdf` with 20 puzzles (two per page) and solutions at the end.

--- a/crossword_book/claude_generator.py
+++ b/crossword_book/claude_generator.py
@@ -1,0 +1,46 @@
+import os
+import json
+from typing import List
+
+import anthropic
+
+from .pdf_book import Puzzle
+
+
+def generate_puzzles_with_claude(theme: str, num: int, size: int = 13) -> List[Puzzle]:
+    """Generate crossword puzzles using Anthropic's Claude API.
+
+    The function sends a prompt asking Claude to create ``num`` crossword grids
+    related to ``theme``. Claude is instructed to respond with JSON like:
+
+    ``{"puzzles": [{"grid": [["A", ""], ...], "words": ["WORD", ...]}, ...]}``
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY environment variable not set")
+
+    client = anthropic.Anthropic(api_key=api_key)
+    prompt = (
+        f"Generate {num} crossword puzzles on the theme '{theme}'. "
+        "Return JSON with a 'puzzles' list where each item has 'grid' (a 2D "
+        "array of letters, using empty strings for blanks) and 'words' used."
+    )
+
+    msg = client.messages.create(
+        model="claude-3-sonnet-20240229",
+        max_tokens=1000,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    content = msg.content
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Claude response was not valid JSON") from exc
+
+    puzzles: List[Puzzle] = []
+    for item in data.get("puzzles", []):
+        grid = item.get("grid")
+        words = item.get("words", [])
+        if isinstance(grid, list) and all(isinstance(row, list) for row in grid):
+            puzzles.append(Puzzle(grid=grid, words=words))
+    return puzzles

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from crossword_book.word_provider import fetch_theme_words
 from crossword_book.crossword import generate_crossword
 from crossword_book.pdf_book import CrosswordPDFBook, Puzzle
+from crossword_book.claude_generator import generate_puzzles_with_claude
 import argparse
 import random
 
@@ -11,17 +12,21 @@ def main() -> None:
     parser.add_argument("num_puzzles", type=int, help="Number of puzzles to generate")
     parser.add_argument("--size", default="6x9", choices=["6x9", "8x11"], help="Book size")
     parser.add_argument("--output", default="crossword_book.pdf", help="Output PDF filename")
+    parser.add_argument("--use-claude", action="store_true", help="Generate puzzles with Claude instead of the local generator")
     args = parser.parse_args()
 
     words = fetch_theme_words(args.theme, max_words=100)
     if not words:
         raise SystemExit("Could not fetch words for theme")
 
-    puzzles = []
-    for _ in range(args.num_puzzles):
-        random_words = random.sample(words, min(len(words), 10))
-        grid = generate_crossword(random_words)
-        puzzles.append(Puzzle(grid=grid, words=random_words))
+    if args.use_claude:
+        puzzles = generate_puzzles_with_claude(args.theme, args.num_puzzles)
+    else:
+        puzzles = []
+        for _ in range(args.num_puzzles):
+            random_words = random.sample(words, min(len(words), 10))
+            grid = generate_crossword(random_words)
+            puzzles.append(Puzzle(grid=grid, words=random_words))
 
     book = CrosswordPDFBook(args.theme, puzzles, size=args.size)
     book.build(args.output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 reportlab
+anthropic


### PR DESCRIPTION
## Summary
- add anthropic API integration for puzzle creation
- toggle puzzle generation with `--use-claude`
- document API key usage and new option
- add anthropic package requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686536a4242c8320b3d26d210f5b2bf8