### PR TITLE
Add simple Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This tool generates crossword puzzle books for Amazon KDP. Provide a theme and n
 - Python 3.10+
 - `requests`
 - `reportlab`
+- `flask`
 
 Install dependencies:
 ```bash
@@ -21,3 +22,12 @@ python main.py "animals" 20 --size 6x9 --output animals_book.pdf
 This will create `animals_book.pdf` with 20 puzzles (two per page) and solutions at the end.
 
 The script fetches words related to the theme using the Datamuse API.
+
+## Web interface
+You can also run a simple web interface:
+
+```bash
+python webapp.py
+```
+
+Then open `http://localhost:5000` in your browser to generate puzzles and download a PDF.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 reportlab
+flask

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,98 @@
+import random
+from io import BytesIO
+
+from flask import Flask, request, render_template_string, send_file
+
+from crossword_book.word_provider import fetch_theme_words
+from crossword_book.crossword import generate_crossword
+from crossword_book.pdf_book import CrosswordPDFBook, Puzzle
+
+app = Flask(__name__)
+
+INDEX_HTML = """
+<!doctype html>
+<title>Crossword Puzzle Generator</title>
+<h1>Create Crossword Puzzles</h1>
+<form method="post" action="/generate">
+  Theme: <input name="theme" required><br>
+  Number of puzzles: <input type="number" name="num" value="1" min="1" max="10"><br>
+  <button type="submit">Generate</button>
+</form>
+"""
+
+PUZZLE_HTML = """
+<!doctype html>
+<title>Puzzles for {{theme}}</title>
+<h1>Puzzles for {{theme}}</h1>
+{% for grid in grids %}
+<table border="1" style="border-collapse: collapse; margin-bottom:20px">
+  {% for row in grid %}
+  <tr>
+    {% for cell in row %}
+    <td style="width:20px;height:20px;text-align:center">{{cell}}</td>
+    {% endfor %}
+  </tr>
+  {% endfor %}
+</table>
+{% endfor %}
+<form method="post" action="/pdf">
+  <input type="hidden" name="theme" value="{{theme}}">
+  <input type="hidden" name="num" value="{{num}}">
+  <button type="submit">Download PDF</button>
+</form>
+"""
+
+@app.route("/")
+def index():
+    return INDEX_HTML
+
+
+@app.route("/generate", methods=["POST"])
+def generate():
+    theme = request.form.get("theme", "").strip()
+    try:
+        num = int(request.form.get("num", 1))
+    except ValueError:
+        num = 1
+    if not theme:
+        return "Theme required", 400
+
+    words = fetch_theme_words(theme, max_words=100)
+    if not words:
+        return "Could not fetch words for theme", 400
+
+    grids = []
+    for _ in range(num):
+        sample = random.sample(words, min(len(words), 10))
+        grid = generate_crossword(sample)
+        grids.append(grid)
+    return render_template_string(PUZZLE_HTML, theme=theme, grids=grids, num=num)
+
+
+@app.route("/pdf", methods=["POST"])
+def pdf():
+    theme = request.form.get("theme", "")
+    try:
+        num = int(request.form.get("num", 1))
+    except ValueError:
+        num = 1
+
+    words = fetch_theme_words(theme, max_words=100)
+    if not words:
+        return "Could not fetch words for theme", 400
+
+    puzzles = []
+    for _ in range(num):
+        sample = random.sample(words, min(len(words), 10))
+        grid = generate_crossword(sample)
+        puzzles.append(Puzzle(grid=grid, words=sample))
+
+    book = CrosswordPDFBook(theme, puzzles)
+    buffer = BytesIO()
+    book.build(buffer)
+    buffer.seek(0)
+    return send_file(buffer, as_attachment=True, download_name="crossword_book.pdf", mimetype="application/pdf")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a small Flask web app to generate puzzles and download a PDF
- document the web interface in README
- include Flask in project requirements

## Testing
- `python -m py_compile webapp.py crossword_book/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68653f031d1c8320aa80d3510130349e