### PR TITLE
Fix puzzle generation logic and add Claude option

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from crossword_book.word_provider import fetch_theme_words
 from crossword_book.crossword import generate_crossword
 from crossword_book.pdf_book import CrosswordPDFBook, Puzzle
+from crossword_book.claude_generator import generate_puzzles_with_claude
 import argparse
 import random
 
@@ -11,12 +12,25 @@ def main() -> None:
     parser.add_argument("num_puzzles", type=int, help="Number of puzzles to generate")
     parser.add_argument("--size", default="6x9", choices=["6x9", "8x11"], help="Book size")
     parser.add_argument("--output", default="crossword_book.pdf", help="Output PDF filename")
+    parser.add_argument(
+        "--use-claude",
+        action="store_true",
+        help="Generate puzzles with Claude instead of the local generator",
+    )
     args = parser.parse_args()
 
     words = fetch_theme_words(args.theme, max_words=100)
     if not words:
         raise SystemExit("Could not fetch words for theme")
 
+    if args.use_claude:
+        puzzles = generate_puzzles_with_claude(args.theme, args.num_puzzles)
+    else:
+        puzzles = []
+        for _ in range(args.num_puzzles):
+            random_words = random.sample(words, min(len(words), 10))
+            grid = generate_crossword(random_words)
+            puzzles.append(Puzzle(grid=grid, words=random_words))
 
     book = CrosswordPDFBook(args.theme, puzzles, size=args.size)
     book.build(args.output)


### PR DESCRIPTION
## Summary
- restore loop that builds puzzles for the requested count
- add `--use-claude` CLI flag to generate puzzles with the Claude API
- construct `puzzles` list before creating the PDF

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865431298848320b3f953dc5d22ae98